### PR TITLE
Use backslash instead of forward slash

### DIFF
--- a/backslash.rule
+++ b/backslash.rule
@@ -1,5 +1,5 @@
 # Match a backslash.
 srl: begin with backslash must end
-match: "/"
-no match: "/a"
-no match: "a/"
+match: "\"
+no match: "\a"
+no match: "a\"


### PR DESCRIPTION
This runs and passes the rule test with the fixed backslash method

There's a separate pull request to SRL-JavaScript repo to fix the backslash and carriage returns methods